### PR TITLE
Widget test for Django 1.8 and admin interface

### DIFF
--- a/music/forms.py
+++ b/music/forms.py
@@ -1,8 +1,9 @@
 # django imports
 from django import forms
+from django.contrib.admin.forms import forms as adminforms
 
 # third party imports
-from db_file_storage.form_widgets import DBClearableFileInput
+from db_file_storage.form_widgets import DBClearableFileInput, DBAdminClearableFileInput
 
 # project imports
 from music.models import CD
@@ -15,4 +16,14 @@ class CDForm(forms.ModelForm):
         widgets = {
             'disc': DBClearableFileInput,
             'cover': DBClearableFileInput,
+        }
+
+
+class CDAdminForm(adminforms.ModelForm):
+    class Meta:
+        model = CD
+        exclude = []
+        widgets = {
+            'disc': DBAdminClearableFileInput,
+            'cover': DBAdminClearableFileInput,
         }

--- a/music/tests.py
+++ b/music/tests.py
@@ -10,7 +10,7 @@ from django.core.urlresolvers import reverse
 from django.test import TestCase
 
 # project imports
-from .forms import CDForm
+from .forms import CDForm, CDAdminForm
 from .models import CD, CDDisc, CDCover, SoundDevice
 
 
@@ -155,6 +155,18 @@ class AddEditAndDeleteCDsTests(TestCase):
         )
         cd = get_cd(cd_key='btw')
         form = CDForm(instance=cd)
+        assert '>btw_disc1.png</a>' in form.as_p()
+
+    def test_admin_form_widget_shows_proper_filename(self):
+        self.add_or_edit_cd(
+            method='add',
+            cd_key='btw',
+            with_cover_pic=False,
+            with_disc_pic=True,
+            disc_pic_nbr=1
+        )
+        cd = get_cd(cd_key='btw')
+        form = CDAdminForm(instance=cd)
         assert '>btw_disc1.png</a>' in form.as_p()
 
     def test_files_operations(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==1.7
-Pillow==2.7.0
-django-db-file-storage==0.2.7
-wsgiref==0.1.2
+Django>=1.7
+Pillow>=2.7.0
+django-db-file-storage>=0.2.8
+wsgiref>=0.1.2


### PR DESCRIPTION
These are the tests relative to my pull request on db_file_storage.
I've added some tests for the admin widget. I did not add the admin in settings.py to test. I you think it would be usefull too, just let me know, I have the files dandling on my local repo.